### PR TITLE
Update init.go

### DIFF
--- a/init.go
+++ b/init.go
@@ -48,6 +48,7 @@ func init() {
 	Region = os.Getenv("REGION")
 	KmsKeyId = os.Getenv("KMS")
 	AwsAccount = os.Getenv("ACCOUNT")
+	Application = os.Getenv("APPLICATION")
 	AwsSession = session.Must(session.NewSession(&aws.Config{Region: aws.String(Region)}))
 	KMS = kms.New(AwsSession)
 }


### PR DESCRIPTION
Otherwise this will fail

```
EncryptionContext: map[string]*string{
			`account`:     aws.String(AwsAccount),
			`application`: aws.String(Application),
		},
```

with 
`ValidationException: Invalid EncryptionContext`